### PR TITLE
Add NapCat docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+napcat_data/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # DailyLogAPI
 record daily activity
+
+## Running NapCat
+The repository includes a Docker setup for the NapCat chatbot. To start the service, run:
+
+```bash
+./start_napcat.sh
+```
+
+This script writes a `.env` file with the current user and group IDs, ensures a persistent data directory `napcat_data/` exists, and then starts the container defined in `docker-compose.yml`.
+
+Once started, open [http://localhost:6099/webui](http://localhost:6099/webui) in your browser to scan the QR code for login.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  napcat:
+    image: mlikiowa/napcat-docker:latest
+    container_name: napcat
+    ports:
+      - "3001:3001"  # WebSocket（你的 Go 程序连接）
+      - "6099:6099"  # WebUI 登录页面
+    environment:
+      - NAPCAT_UID=${NAPCAT_UID}
+      - NAPCAT_GID=${NAPCAT_GID}
+    volumes:
+      - ./napcat_data:/root/.local/share/NapCat
+    restart: unless-stopped

--- a/start_napcat.sh
+++ b/start_napcat.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# ===== 设置项目路径 =====
+WORKDIR=$(dirname "$0")
+cd "$WORKDIR"
+
+# ===== 检查并获取 UID/GID =====
+UID_VAL=$(id -u)
+GID_VAL=$(id -g)
+
+# ===== 写入 .env 文件 =====
+cat > .env <<EOF2
+NAPCAT_UID=$UID_VAL
+NAPCAT_GID=$GID_VAL
+EOF2
+
+echo "✅ 已写入 .env:"
+cat .env
+
+# ===== 创建数据挂载目录 =====
+mkdir -p napcat_data
+echo "📁 已确保持久化目录 napcat_data 存在"
+
+# ===== 启动容器 =====
+echo "🚀 正在启动 NapCat 实例..."
+docker compose up -d
+
+echo "🟢 NapCat 启动完成，请用浏览器访问进行扫码登录："
+echo "👉 http://localhost:6099/webui"


### PR DESCRIPTION
## Summary
- add a `start_napcat.sh` helper script
- add `docker-compose.yml` for the NapCat container
- update `.gitignore` to exclude `napcat_data`
- document NapCat usage in the README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686239ba193c832c8f833277806ab479